### PR TITLE
improved error handling and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*Ckeylock.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "cryptostream",
  "dashmap",
  "futures-util",
+ "hex",
  "lazy_static",
  "oneshot",
  "ron",
@@ -451,6 +452,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -156,8 +156,8 @@ mod tests {
         let api = CKeyLockAPI::new("127.0.0.1:8080", Some("helloworld"));
         let mut connection = api.connect().await.unwrap();
 
-        let key = b"test_key".to_vec();
-        let value = b"test_value".to_vec();
+        let key = b"popa".to_vec();
+        let value = b"pisya".to_vec();
 
         let result = connection.set(key.clone(), value.clone()).await;
         assert!(result.is_ok());
@@ -216,7 +216,7 @@ mod tests {
     pub async fn req() {
         let api = CKeyLockAPI::new("127.0.0.1:8080", Some("helloworld"));
         let mut connection = api.connect().await.unwrap();
-        let key = b"test_key".to_vec();
+        let key = b"popa".to_vec();
         let res = connection.get(key.clone()).await.unwrap();
         println!("Response: {:?}", res.unwrap());
     }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,7 @@ ckeylock-core = "0.1.1"
 cryptostream = "0.3.2"
 dashmap = { version = "6.1.0", features = ["serde"] }
 futures-util = "0.3.31"
+hex = "0.4.3"
 lazy_static = "1.5.0"
 oneshot = "0.1.11"
 ron = "0.9.0"

--- a/server/src/conf.rs
+++ b/server/src/conf.rs
@@ -12,12 +12,30 @@ pub struct Config {
 
 impl Config {
     pub fn from_toml(path: &str) -> Result<Self, ConfigError> {
-        let data = std::fs::read_to_string(path)?;
+        let data = match std::fs::read_to_string(path) {
+            Ok(data) => data,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    return Err(ConfigError::NotFound);
+                } else {
+                    return Err(ConfigError::Fs(e));
+                }
+            }
+        };
         let config: Config = toml::from_str(&data)?;
         Ok(config)
     }
     pub fn from_ron(path: &str) -> Result<Self, ConfigError> {
-        let data = std::fs::read_to_string(path)?;
+        let data = match std::fs::read_to_string(path) {
+            Ok(data) => data,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    return Err(ConfigError::NotFound);
+                } else {
+                    return Err(ConfigError::Fs(e));
+                }
+            }
+        };
         let config: Config = ron::from_str(&data)?;
         Ok(config)
     }
@@ -36,4 +54,6 @@ pub enum ConfigError {
     Toml(#[from] toml::de::Error),
     #[error("RON parse error: {0}")]
     Ron(#[from] ron::de::SpannedError),
+    #[error("Config not found")]
+    NotFound,
 }

--- a/server/src/storage.rs
+++ b/server/src/storage.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
 };
 use thiserror::Error;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 pub struct Storage {
     data: DashMap<Vec<u8>, Vec<u8>>,
@@ -95,34 +95,34 @@ impl Storage {
     pub fn set(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<Vec<u8>, StorageError> {
         debug!(
             "Setting key: {:?} with value of length: {}",
-            key,
+            hex::encode(&key),
             value.len()
         );
         self.data.insert(key.clone(), value);
         self.sync()?;
-        info!("Key {:?} set successfully.", key);
+        info!("Key {:?} set successfully.", hex::encode(&key));
         Ok(key)
     }
 
     pub fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, StorageError> {
-        debug!("Getting value for key: {:?}", key);
+        debug!("Getting value for key: {:?}", hex::encode(&key));
         let value = self.data.get(&key).map(|v| v.clone());
         if value.is_some() {
-            info!("Key {:?} found.", key);
+            info!("Key {:?} found.", hex::encode(&key));
         } else {
-            warn!("Key {:?} not found.", key);
+            warn!("Key {:?} not found.", hex::encode(&key));
         }
         Ok(value)
     }
 
     pub fn delete(&mut self, key: Vec<u8>) -> Result<Option<Vec<u8>>, StorageError> {
-        debug!("Deleting key: {:?}", key);
+        debug!("Deleting key: {:?}", hex::encode(&key));
         let value = self.data.remove(&key).map(|v| v.clone()).map(|(k, v)| k);
         self.sync()?;
         if value.is_some() {
-            info!("Key {:?} deleted successfully.", key);
+            info!("Key {:?} deleted successfully.", hex::encode(&key));
         } else {
-            warn!("Key {:?} not found for deletion.", key);
+            warn!("Key {:?} not found for deletion.", hex::encode(&key));
         }
         Ok(value)
     }
@@ -135,12 +135,12 @@ impl Storage {
     }
 
     pub fn exists(&self, key: Vec<u8>) -> Result<bool, StorageError> {
-        debug!("Checking existence of key: {:?}", key);
+        debug!("Checking existence of key: {:?}", hex::encode(&key));
         let exists = self.data.contains_key(&key);
         if exists {
-            info!("Key {:?} exists.", key);
+            info!("Key {:?} exists.", hex::encode(&key));
         } else {
-            warn!("Key {:?} does not exist.", key);
+            warn!("Key {:?} does not exist.", hex::encode(&key));
         }
         Ok(exists)
     }


### PR DESCRIPTION
This pull request includes several changes to improve error handling, logging, and dependency management in the project. The most important changes include updates to the `Config` struct error handling, improved logging with hex encoding for keys, and additional dependencies in the `Cargo.toml` file.

### Error Handling Improvements:
* [`server/src/conf.rs`](diffhunk://#diff-01682eeecc9a1c34355d6b3a15bf813003d0e87e83b5400a504b0ba0da45ddfbL15-R38): Enhanced error handling in the `Config` struct by adding detailed error matching for file reading operations and introducing a new `ConfigError::NotFound` variant. [[1]](diffhunk://#diff-01682eeecc9a1c34355d6b3a15bf813003d0e87e83b5400a504b0ba0da45ddfbL15-R38) [[2]](diffhunk://#diff-01682eeecc9a1c34355d6b3a15bf813003d0e87e83b5400a504b0ba0da45ddfbR57-R58)
* [`server/src/main.rs`](diffhunk://#diff-01fd5002f7585d6f2b853a8c83e6c0a1acb2b16b6e6f8f581fb3365377d331bcL24-R37): Modified the `main` function to handle errors using `unwrap_or_else` with detailed panic messages instead of returning a `Result`.

### Logging Improvements:
* [`server/src/storage.rs`](diffhunk://#diff-52361f3944c4f96bb727dcccd0b5c2097d7568987de31784ae0a277bd1dfc1b9L98-R125): Updated logging to use hex encoding for keys in the `Storage` struct methods to improve readability and debugging. [[1]](diffhunk://#diff-52361f3944c4f96bb727dcccd0b5c2097d7568987de31784ae0a277bd1dfc1b9L98-R125) [[2]](diffhunk://#diff-52361f3944c4f96bb727dcccd0b5c2097d7568987de31784ae0a277bd1dfc1b9L138-R143)

### Dependency Management:
* [`server/Cargo.toml`](diffhunk://#diff-36a55fca956d2696a4fb89bc9847360169a01e70aa29641862a78ca833e9becfR16): Added the `hex` crate as a new dependency to support hex encoding in logging.

### Test Updates:
* [`api/src/lib.rs`](diffhunk://#diff-8eb1bfebbf93beb9e7ced3706e9a82a6ce2086e62b4cde4a95d26e82eacd9c47L159-R160): Updated test keys and values to new strings in the `mod tests` section. [[1]](diffhunk://#diff-8eb1bfebbf93beb9e7ced3706e9a82a6ce2086e62b4cde4a95d26e82eacd9c47L159-R160) [[2]](diffhunk://#diff-8eb1bfebbf93beb9e7ced3706e9a82a6ce2086e62b4cde4a95d26e82eacd9c47L219-R219)