### PR TITLE
Batch get update + some security updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "bincode",
- "ckeylock-core 0.1.1",
+ "ckeylock-core 0.1.2",
  "clap",
  "cryptostream",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,12 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,9 +163,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "block-buffer"
@@ -190,9 +181,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -215,11 +206,11 @@ dependencies = [
 
 [[package]]
 name = "ckeylock"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "bincode",
- "ckeylock-core 0.1.2",
+ "ckeylock-core 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
  "cryptostream",
  "dashmap",
@@ -228,7 +219,6 @@ dependencies = [
  "lazy_static",
  "lru",
  "oneshot",
- "ron",
  "serde",
  "serde_json",
  "sha3",
@@ -242,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "ckeylock-api"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
- "ckeylock-core 0.1.1",
+ "ckeylock-core 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "serde_json",
  "thiserror",
@@ -254,9 +244,7 @@ dependencies = [
 
 [[package]]
 name = "ckeylock-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b308bfc9533745eb6f941baec30f0cf54b99fe401c7ed4a5aad1abf6a3a4ed59"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -265,7 +253,9 @@ dependencies = [
 
 [[package]]
 name = "ckeylock-core"
-version = "0.1.2"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27857f59fa06b92a30af42e906791d25e4a3a118755146265c1f3266f5e6cffd"
 dependencies = [
  "serde",
  "serde_json",
@@ -274,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -284,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -395,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "digest"
@@ -417,9 +407,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -599,9 +589,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -645,15 +635,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -673,9 +663,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -697,9 +687,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -771,9 +761,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -803,9 +793,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -873,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -897,13 +887,12 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
- "zerocopy",
 ]
 
 [[package]]
@@ -936,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -988,19 +977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "ron"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
-dependencies = [
- "base64",
- "bitflags",
- "serde",
- "serde_derive",
- "unicode-ident",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,9 +984,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -1151,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -1233,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1589,9 +1565,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckeylock-api"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 readme.workspace = true
 repository.workspace = true
@@ -8,12 +8,12 @@ license.workspace = true
 description = "API for ckeylock."
 
 [dependencies]
-ckeylock-core = "0.1.1"
+ckeylock-core = "0.1.3"
 futures-util = "0.3.31"
 serde_json = "1.0.140"
 thiserror = "2.0.12"
-tokio = { version = "1.44.1", features = ["sync"] }
+tokio = { version = "1.44.2", features = ["sync"] }
 tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 
 [dev-dependencies]
-tokio = { version = "1.44.1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.44.2", features = ["rt", "rt-multi-thread", "macros"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckeylock-core"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 readme.workspace = true
 repository.workspace = true

--- a/core/src/request.rs
+++ b/core/src/request.rs
@@ -31,6 +31,6 @@ impl RequestWrapper {
         &self.req
     }
     pub fn to_string(&self) -> String {
-        serde_json::to_string(self).unwrap()
+        serde_json::to_string_pretty(self).unwrap()
     }
 }

--- a/core/src/request.rs
+++ b/core/src/request.rs
@@ -7,6 +7,7 @@ pub enum Request {
     List,
     Exists { key: Vec<u8> },
     Count,
+    BatchGet { keys: Vec<Vec<u8>> },
     Clear,
 }
 

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -41,7 +41,7 @@ pub struct ErrorResponse {
 }
 impl ErrorResponse {
     pub fn to_string(&self) -> String {
-        serde_json::to_string(self).unwrap()
+        serde_json::to_string_pretty(self).unwrap()
     }
 }
 

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -53,5 +53,6 @@ pub enum ResponseData {
     ListResponse { keys: Vec<Vec<u8>> },
     ExistsResponse { exists: bool },
     CountResponse { count: usize },
+    BatchGetResponse { values: Vec<Option<Vec<u8>>> },
     ClearResponse,
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,7 @@ description = "A secure and fast secret manager"
 [dependencies]
 aes-gcm = "0.10.3"
 bincode = { version = "2.0.1", features = ["serde"] }
-ckeylock-core = "0.1.1"
+ckeylock-core = { path = "../core" } # "0.1.1"
 clap = { version = "4.5.35", features = ["derive"] }
 cryptostream = "0.3.2"
 dashmap = { version = "6.1.0", features = ["serde"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckeylock"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 readme.workspace = true
 repository.workspace = true
@@ -10,21 +10,20 @@ description = "A secure and fast secret manager"
 [dependencies]
 aes-gcm = "0.10.3"
 bincode = { version = "2.0.1", features = ["serde"] }
-ckeylock-core = { path = "../core" } # "0.1.1"
+ckeylock-core = "0.1.3"
 clap = { version = "4.5.35", features = ["derive"] }
 cryptostream = "0.3.2"
 dashmap = { version = "6.1.0", features = ["serde"] }
 futures-util = "0.3.31"
 hex = "0.4.3"
 lazy_static = "1.5.0"
-lru = "0.13.0"
+lru = "0.14.0"
 oneshot = "0.1.11"
-ron = "0.9.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 sha3 = "0.10.8"
 thiserror = "2.0.12"
-tokio = { version = "1.44.1", features = [
+tokio = { version = "1.44.2", features = [
     "rt",
     "rt-multi-thread",
     "macros",

--- a/server/src/conf.rs
+++ b/server/src/conf.rs
@@ -23,26 +23,6 @@ impl Config {
         let config: Config = toml::from_str(&data)?;
         Ok(config)
     }
-    pub fn from_ron(path: &str) -> Result<Self, ConfigError> {
-        let data = match std::fs::read_to_string(path) {
-            Ok(data) => data,
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    return Err(ConfigError::NotFound);
-                } else {
-                    return Err(ConfigError::Fs(e));
-                }
-            }
-        };
-        let config: Config = ron::from_str(&data)?;
-        Ok(config)
-    }
-    pub fn to_toml(&self) -> String {
-        toml::to_string_pretty(self).unwrap()
-    }
-    pub fn to_ron(&self) -> String {
-        ron::to_string(self).unwrap()
-    }
 }
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
@@ -50,8 +30,6 @@ pub enum ConfigError {
     Fs(#[from] std::io::Error),
     #[error("TOML parse error: {0}")]
     Toml(#[from] toml::de::Error),
-    #[error("RON parse error: {0}")]
-    Ron(#[from] ron::de::SpannedError),
     #[error("Config not found")]
     NotFound,
 }


### PR DESCRIPTION
This pull request introduces a new `batch_get` feature across the `ckeylock` ecosystem, allowing multiple keys to be retrieved in a single request. It also includes dependency updates, code cleanup, and minor improvements to JSON serialization.

### New `batch_get` Feature:

* [`api/src/lib.rs`](diffhunk://#diff-8eb1bfebbf93beb9e7ced3706e9a82a6ce2086e62b4cde4a95d26e82eacd9c47L110-R117): Added a `batch_get` method to `CKeyLockConnection` for retrieving multiple keys in a single request. A corresponding test, `test_batch_get`, was added to validate the functionality. [[1]](diffhunk://#diff-8eb1bfebbf93beb9e7ced3706e9a82a6ce2086e62b4cde4a95d26e82eacd9c47L110-R117) [[2]](diffhunk://#diff-8eb1bfebbf93beb9e7ced3706e9a82a6ce2086e62b4cde4a95d26e82eacd9c47R275-R299)
* [`core/src/request.rs`](diffhunk://#diff-606421d1f29cde53338ad60fe89528aa22e1a0e9fe564c974735827ccee9fe00R10): Added a new `BatchGet` variant to the `Request` enum.
* [`core/src/response.rs`](diffhunk://#diff-0c35f914913508debed0242a19dc4f20d9dff312239f59437672ba4aa0472eb7R56): Added a `BatchGetResponse` variant to the `ResponseData` enum.
* [`server/src/executor.rs`](diffhunk://#diff-683f5ed3914cd51f9ccab66a47628cd7aba3a3268b51fabde2f29da4c6d0798bR31-R36): Implemented `batch_get` handling in the `Executor` and added support for the `BatchGet` command in `ExecutorCommands`. [[1]](diffhunk://#diff-683f5ed3914cd51f9ccab66a47628cd7aba3a3268b51fabde2f29da4c6d0798bR31-R36) [[2]](diffhunk://#diff-683f5ed3914cd51f9ccab66a47628cd7aba3a3268b51fabde2f29da4c6d0798bR87-R94) [[3]](diffhunk://#diff-683f5ed3914cd51f9ccab66a47628cd7aba3a3268b51fabde2f29da4c6d0798bR163-R169) [[4]](diffhunk://#diff-683f5ed3914cd51f9ccab66a47628cd7aba3a3268b51fabde2f29da4c6d0798bR216-R219)
* [`server/src/storage.rs`](diffhunk://#diff-52361f3944c4f96bb727dcccd0b5c2097d7568987de31784ae0a277bd1dfc1b9L128-R158): Added a `batch_get` method to the `Storage` struct to retrieve multiple keys efficiently, leveraging caching where possible.

### Dependency Updates:

* Updated `ckeylock-core` to version `0.1.3` across `api`, `core`, and `server` packages. [[1]](diffhunk://#diff-d67dd40ca36e789733ce93b2652cf7d7ec7c4dbda478858d1c3e98aad63e21b6L3-R19) [[2]](diffhunk://#diff-ac4e3071598a47848866c532150a233af5159d2757dab53572781ed09e13fbeeL3-R3) [[3]](diffhunk://#diff-36a55fca956d2696a4fb89bc9847360169a01e70aa29641862a78ca833e9becfL13-R26)
* Updated `tokio` to version `1.44.2` in both runtime and development dependencies. [[1]](diffhunk://#diff-d67dd40ca36e789733ce93b2652cf7d7ec7c4dbda478858d1c3e98aad63e21b6L3-R19) [[2]](diffhunk://#diff-36a55fca956d2696a4fb89bc9847360169a01e70aa29641862a78ca833e9becfL13-R26)
* Updated `lru` to version `0.14.0` in the `server` package.

### Code Cleanup and Improvements:

* `core/src/request.rs` and `core/src/response.rs`: Updated JSON serialization to use `serde_json::to_string_pretty` for better readability in logs and debugging. [[1]](diffhunk://#diff-606421d1f29cde53338ad60fe89528aa22e1a0e9fe564c974735827ccee9fe00L33-R34) [[2]](diffhunk://#diff-0c35f914913508debed0242a19dc4f20d9dff312239f59437672ba4aa0472eb7L44-R44)
* [`server/src/conf.rs`](diffhunk://#diff-01682eeecc9a1c34355d6b3a15bf813003d0e87e83b5400a504b0ba0da45ddfbL26-L54): Removed unused RON serialization methods and dependencies to simplify the configuration code.